### PR TITLE
Update axestype.pm

### DIFF
--- a/Graph/axestype.pm
+++ b/Graph/axestype.pm
@@ -1521,12 +1521,12 @@ sub set_max_min
     # First, calculate some decent values
     if ( $self->{two_axes} ) 
     {   # XXX this is almost certainly a bug: this key is not set anywhere
-        my $min_range_1 = defined($self->{min_range_1})
-                ? $self->{min_range_1}
-                : $self->{min_range};
-        my $min_range_2 = defined($self->{min_range_2})
-                ? $self->{min_range_2}
-                : $self->{min_range};
+        my $min_range_1 = defined($self->{y1_min_range})
+                ? $self->{y1_min_range}
+                : $self->{y_min_range};
+        my $min_range_2 = defined($self->{y2_min_range})
+                ? $self->{y2_min_range}
+                : $self->{y_min_range};
 
         my(@y_min, @y_max);
         for my $nd (1 .. $self->{_data}->num_sets)


### PR DESCRIPTION
Original patch correcting min_range -> y_min_range, without the adjust_axes option.
